### PR TITLE
Returns array instead of object

### DIFF
--- a/useFunctionDebouncer.js
+++ b/useFunctionDebouncer.js
@@ -17,5 +17,5 @@ export const useFunctionDebouncer = () => {
         setTimer(timer)
     }
 
-    return {debounce, cancelDebounce}
+    return [debounce, cancelDebounce]
 }


### PR DESCRIPTION
# Goals
- Change return signature to an array of functions

## Notes
- This is a breaking change. 

Issue: https://github.com/aej11a/use-function-debouncer/issues/1